### PR TITLE
(SLV-221) Update simplecov to 0.16.0

### DIFF
--- a/lib/gem_of.rb
+++ b/lib/gem_of.rb
@@ -23,7 +23,7 @@ module GemOf
       gem "rototiller", "~> 1.0"
       gem "rspec",      "~> 3.4.0"
       gem "rubocop",    "~> 0.49.1" # used in tests. pinned
-      gem "simplecov",  "~> 0.14.0" # used in tests
+      gem "simplecov",  "~> 0.16.0" # used in tests
       gem "yardstick",  "~> 0.9.0"  # used in tests
       gem "markdown",   "~> 0"
       gem "flay",       "~> 2.10.0" # used in tests


### PR DESCRIPTION
gem_of is used by the ref_arch_setup project; when updating the bolt version in ref_arch_setup from 0.17 to 0.21.8 the following dependency conflict was encountered:

```
Resolving dependencies...
Bundler could not find compatible versions for gem "flay":
  In Gemfile:
    flay (~> 2.10.0)

    rubycritic was resolved to 3.4.0, which depends on
      flay (~> 2.8)

Bundler could not find compatible versions for gem "public_suffix":
  In Gemfile:
    public_suffix (~> 1)

    ref_arch_setup was resolved to 0.0.2, which depends on
      bolt (~> 0.21.8) was resolved to 0.21.8, which depends on
        addressable (~> 2.5) was resolved to 2.5.1, which depends on
          public_suffix (>= 2.0.2, ~> 2.0)

Bundler could not find compatible versions for gem "simplecov":
  In Gemfile:
    simplecov (~> 0.14.0)

    coveralls was resolved to 0.8.22, which depends on
      simplecov (~> 0.16.1)
```

Updating simplecov to `~> 0.16.0` seems to resolve the issue.

