### PR TITLE
(slv-254) ability to set rototiller version via envvar in gem of bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,33 @@ Gemfiles are typically used solely for gems in development and testing. Are you 
 use the gem_of gems!
 
 we bring you:
+* rake, rototiller, rspec, rubocop, simplecov, yardstick, markdown, rubycritic, and coveralls for all your dev and unit testing needs.
+* beaker for your system testing needs, AND we ensure the bundle will install consistently across ruby versions by pinning old dependencies that don't seem to like following semver rules.
 
-rake, rototiller, rspec, rubocop, simplecov, yardstick, markdown, flay, flog, roodi, rubycritic, and coveralls for all your dev and unit testing needs.
-
-we bring you: beaker for your system testing needs, AND we ensure the bundle will install consistently across ruby versions by pinning old dependencies that don't seem to like following semver rules.
-
-later we'll supply a bunch of canned rake tasks to bring this all together from the CLI or CI (see our Rakefile)
+later we'll supply a bunch of canned rake tasks to bring this all together from the CLI or CI (see our Rakefile).
 
 ## currently installed gems
-
+### dev and unit testing
+* [coveralls](https://docs.coveralls.io/): "Coveralls is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered."
+* [markdown](https://en.wikipedia.org/wiki/Markdown): "A lightweight markup language with plain text formatting syntax."
 * [rake](https://github.com/ruby/rake): "A make-like build utility for Ruby."
 * [rototiller](https://github.com/puppetlabs/rototiller): "A Rake helper library for command-oriented tasks."
 * [rspec](http://rspec.info/): "Behaviour Driven Development for Ruby."
 * [rubocop](https://github.com/bbatsov/rubocop): "A Ruby static code analyzer, based on the community Ruby style guide."
 * [simplecov](https://github.com/colszowka/simplecov): "Code coverage for Ruby 1.9+ with a powerful configuration library and automatic merging of coverage across test suites."
 * [yardstick](https://github.com/dkubb/yardstick): "A tool for verifying YARD documentation coverage."
-* [markdown](https://en.wikipedia.org/wiki/Markdown): "A lightweight markup language with plain text formatting syntax."
-* [flay](https://github.com/seattlerb/flay): "Flay analyzes code for structural similarities."
-* [flog](https://github.com/seattlerb/flog): "Flog reports the most tortured code in an easy to read pain report."
-* [roodi](https://github.com/roodi/roodi): "Ruby Object Oriented Design Inferometer"
-* [rubycritic](https://github.com/whitesmith/rubycritic): "A Ruby code quality reporter."
-* [coveralls](https://docs.coveralls.io/): "Coveralls is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered."
+
+### system testing
+* [beaker](https://github.com/puppetlabs/beaker): "Beaker is a test harness focused on acceptance testing via interactions between multiple (virtual) machines."
+* [beaker-hostgenerator](https://github.com/puppetlabs/beaker-hostgenerator): "Beaker Host Generator is a command line utility designed to generate beaker host config files using a compact command line SUT specification."
 
 ## locally install this gem
-you can't put this in your Gemfile, because we need to use it to form your Gemfile
+If you are using gem_of for its super-sweet opinion on dependency management for gem development and testing, you can't just add gem_of in your Gemfile, because we need to use it to _form_ your Gemfile. So you can either install it locally (as below), or use gem_of as a submodule.
+
 ```
 gem install --local gem_of
 ```
-or:
+or (use as a submodule):
 ```
 clone git@github.com:puppetlabs/gem_of.git
 cd gem_of
@@ -41,7 +40,7 @@ bundle install
 bundle exec rake gem:build
 bundle exec rake gem:install:local
 ```
-
+you should probably pin your submodule version to a tag of a released,stable version of gem_of.
 ## In your Gemfile
 ```
 require 'gem_of'

--- a/distelli-manifest.yml
+++ b/distelli-manifest.yml
@@ -18,7 +18,5 @@ slv/gem_of:
     - rvm use 2.4.0
     - bundle install --without system_tests
     - bundle exec rake docs:verify
-    - bundle exec rake lint:flay
-    - bundle exec rake lint:flog
     - bundle exec rake lint:rubocop
     - bundle exec rake test:spec

--- a/lib/gem_of.rb
+++ b/lib/gem_of.rb
@@ -20,7 +20,7 @@ module GemOf
       gem "rake"
       # ensure downstream projects get gem_of for rake tasks
       gem "gem_of",     #{GemOf.location_of(@gemof_version)}
-      gem "rototiller", "~> 1.0"
+      gem "rototiller", #{GemOf.location_of(@rototiller_version)}
       gem "rspec",      "~> 3.4.0"
       gem "rubocop",    "~> 0.49.1" # used in tests. pinned
       gem "simplecov",  "~> 0.16.0" # used in tests
@@ -90,6 +90,7 @@ module GemOf
       @gemof_version         = ENV["GEMOF_VERSION"] || "< 500" # any
       @beaker_version        = ENV["BEAKER_VERSION"] || "< 500" # any
       @beaker_abs_version    = ENV["BEAKER_ABS_VERSION"] || "< 500" # any
+      @rototiller_version    = ENV["ROTOTILLER_VERSION"] || "< 500" # any
       #   nokogiri comes along for the ride but needs some restriction too
       if Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new("2.0.0"),
                                                  Gem::Version.new("2.1.5"))

--- a/lib/gem_of.rb
+++ b/lib/gem_of.rb
@@ -26,17 +26,12 @@ module GemOf
       gem "simplecov",  "~> 0.16.0" # used in tests
       gem "yardstick",  "~> 0.9.0"  # used in tests
       gem "markdown",   "~> 0"
-      gem "flay",       "~> 2.10.0" # used in tests
-      gem "flog",       "~> 4.6.0"  # used in tests
-      gem "roodi",      "~> 5.0.0"  # used in tests
-      gem "reek",       "#{@reek_version}"
       gem "coveralls",  require: false # used in tests
 
       group :system_tests do
         gem "beaker",         #{GemOf.location_of(@beaker_version)}
         gem "beaker-hostgenerator"
         gem "beaker-abs",     #{GemOf.location_of(@beaker_abs_version)}
-        gem "nokogiri",       "#{@nokogiri_version}"
         gem "public_suffix",  "#{@public_suffix_version}"
         gem "jwt",            "#{@jwt_version}"
         gem "activesupport", "#{@activesupport_version}"
@@ -53,11 +48,13 @@ module GemOf
         eval(File.read(user_gemfile), binding)
       end
       HEREDOC
-      # rubycritic has trouble in older rubys because of transitive deps
-      unless Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new("2.0.0"),
-                                                     Gem::Version.new("2.1.5"))
+      # we need nokogiri for old versions of ruby (and beaker before 4)
+      if Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new("2.0.0"),
+                                                 Gem::Version.new("2.2.4"))
         @gem_code += <<-HEREDOC
-          gem "rubycritic", "#{@rubycritic_version}"
+          group :system_tests do
+            gem "nokogiri",       "#{@nokogiri_version}"
+          end
         HEREDOC
       end
     end
@@ -85,8 +82,6 @@ module GemOf
       @nokogiri_version      = "< 500" # any
       @jwt_version           = "< 500" # any
       @fog_openstack_version = "< 500" # any
-      @reek_version          = "< 500" # any
-      @rubycritic_version    = "< 500" # any
       @gemof_version         = ENV["GEMOF_VERSION"] || "< 500" # any
       @beaker_version        = ENV["BEAKER_VERSION"] || "< 500" # any
       @beaker_abs_version    = ENV["BEAKER_ABS_VERSION"] || "< 500" # any
@@ -99,8 +94,6 @@ module GemOf
         @jwt_version      = "<  2.0.0"
         @activesupport_version = "<  5.0.0"
         @fog_openstack_version = "<  0.1.23"
-        @reek_version          = "<  4.0.0"
-        @rubycritic_version    = "<  3.0.0"
       elsif Gem::Version.new(RUBY_VERSION).between?(Gem::Version.new("2.1.6"),
                                                     Gem::Version.new("2.2.4"))
         @beaker_version   = ENV["BEAKER_VERSION"] || "<  3.9.0"

--- a/lib/gem_of.rb
+++ b/lib/gem_of.rb
@@ -71,6 +71,8 @@ module GemOf
     private
 
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     # Set instance params for the various gem versions we need based upon ruby
     #   should really only be used in above, will change, over time
     # @api private

--- a/lib/gem_of/rake_tasks.rb
+++ b/lib/gem_of/rake_tasks.rb
@@ -2,10 +2,6 @@ require "fileutils"
 require "rototiller"
 require "yard"
 require "rubocop/rake_task"
-require "flog_task"
-require "flay_task"
-require "roodi_task"
-require "reek/rake/task"
 
 module GemOf
   # a bunch of instances of other rake tasks
@@ -174,31 +170,6 @@ module GemOf
         # this will produce 'lint:rubocop','lint:rubocop:auto_correct' tasks
         RuboCop::RakeTask.new do |task|
           task.options = ["--debug"]
-        end
-
-        # this will produce the 'lint:flog' task
-        allowed_complexity = 585 # <cough!>
-        FlogTask.new :flog, allowed_complexity, %w[lib]
-        # this will produce the 'lint:flay' task
-        allowed_repitition = 0
-        FlayTask.new :flay, allowed_repitition, %w[lib]
-        # this will produce the 'lint:roodi' task
-        RoodiTask.new
-        # this will produce the 'lint:reek' task
-        #   i am Reek
-        Reek::Rake::Task.new do |t|
-          t.fail_on_error = false
-        end
-        # this will produce the 'lint:rubycritic' task
-        begin
-          require "rubycritic/rake_task"
-          RubyCritic::RakeTask.new do |task|
-            task.paths   = FileList["lib/**/*.rb"]
-          end
-          # if rubycritic isn't available (ruby 2.0),
-          # we can still use this Rakefile
-          # rubocop:disable Lint/HandleExceptions
-        rescue LoadError
         end
       end
     end

--- a/lib/gem_of/rake_tasks.rb
+++ b/lib/gem_of/rake_tasks.rb
@@ -214,7 +214,8 @@ module GemOf
             t.rspec_opts = ["--color --format documentation"]
             t.pattern = ENV["SPEC_PATTERN"]
           end
-          # if rspec isn't available, we can still use this Rakefile
+        # if rspec isn't available, we can still use this Rakefile
+        # rubocop:disable Lint/HandleExceptions
         rescue LoadError
         end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@ module GemOf
   # namespace for the future version of this library
   module Version
     # the version string
-    STRING = "0.1.1".freeze
+    STRING = "2.0.0".freeze
   end
 end


### PR DESCRIPTION


    (SLV-254) Updated README to sync gem list, fix minor typos

    (SLV-254) small fixups for rubocop

    (SLV-254) update version to 2 for breaking changes

    (SLV-254) remove extraneous gems

    * remove nokogiri, where possible
      * beaker no longer needs you.  relegated to older ruby/beaker versions
    * largely ununsed linters that cause bundler/gem dependency headaches
    * minimize container image size which use a bundle based on gem_of



    (SLV-254) add ability to set rototiller version via envvar in gem_of bundles