### PR TITLE
(SLV-455) Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+sudo: false
+bundler_args: --jobs 4 --retry 2 --without packaging documentation
+before_install:
+  - gem update --system && gem install bundler --no-document
+script:
+  - "bundle exec rake $CHECK"
+notifications:
+  email: false
+rvm:
+  - 2.6.2
+env:
+  matrix:
+    - "CHECK=lint:rubocop"
+    - "CHECK=test:spec"


### PR DESCRIPTION
This commit adds a .travis.yml config file to enable travis-ci to
kick off testing per PR using the `lint:rubocop` and `test:unit`
rake tasks.